### PR TITLE
Fix macos build

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ cd ../python
 PKG_CONFIG_PATH=../build python -m pip install -ve .
 ```
 
+## mkm's notes:
+
+### Macos build
+
+1. cannot build with macos clang due to a divergence in c++ stdlib. Zig's embeds a lean clang distribution that is easy to install and use (we use as a bazel toolchain in forge)
+2. LTO is not supported in zig's clang build.
+3. malloc.h is not available on macos so many targets don't build (but `spm_encode` does work!)
+4. cmake doesn't find the homebrew installed ICU library despite pkg-config providing the right paths, so we need to pass the path explicitly
+
+
+```console
+$ brew install zig
+$ mkdir build && cd build
+$ CC="zig cc" CXX="zig c++" ICU_ROOT=/opt/homebrew/Cellar/icu4c/74.2 cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D SPM_ENABLE_TCMALLOC=on -D SPM_ENABLE_NFKC_COMPILE=on -DSPM_ENABLE_SHARED=off -DSPM_SANITIZE=off -DSPM_DISABLE_LTO=on ..
+$ make -j16 spm_encode
+```
 
 ## Technical highlights
 - **Purely data driven**: SentencePiece trains tokenization and detokenization

--- a/src/spm_encode_main.cc
+++ b/src/spm_encode_main.cc
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+#include <unistd.h> // usleep on macos
+
 #include "common.h"
 #include "filesystem.h"
 #include "init.h"


### PR DESCRIPTION
This PR adds instructions about how to build `spm_encode` on macos.

Also`usleep` required `unistd.h` in macos (the usleep call was added by us in 5dc8892f)