### PR TITLE
Use #__linux__ insted of #__GLIBC__

### DIFF
--- a/src/bpe_model_trainer.cc
+++ b/src/bpe_model_trainer.cc
@@ -14,7 +14,7 @@
 
 #include "bpe_model_trainer.h"
 
-#ifdef __GLIBC__
+#ifdef __linux__
 #include <malloc.h>
 #endif
 #ifdef TCMALLOC
@@ -487,8 +487,11 @@ util::Status Trainer::Train() {
   }
 
   cache_file.reset();
-  #if defined(TCMALLOC) and defined(__GLIBC__)
+  #if defined(TCMALLOC)
   MallocExtension::instance()->ReleaseFreeMemory();
+  #endif
+
+  #if defined(__linux__)
   malloc_stats();
   #endif
 
@@ -592,15 +595,19 @@ util::Status Trainer::Train() {
   }
 
   LOG(INFO) << "Allocated " << allocated_.size() - unisize << " pairs";
-  #if defined(tcmalloc) and defined(__GLIBC__)
+  #if defined(tcmalloc)
   MallocExtension::instance()->ReleaseFreeMemory();
+  #endif
+  #if defined(__linux__)
   malloc_stats();
   #endif
 
   LOG(INFO) << "Sorting positions...";
   SortSymbolPositions(pool.get(), 0);
-  #if defined(tcmalloc) and defined(__GLIBC__)
+  #if defined(tcmalloc) 
   MallocExtension::instance()->ReleaseFreeMemory();
+  #endif
+  #if defined(__linux__)
   malloc_stats();
   #endif
 

--- a/src/spm_bpe_cache_merge.cc
+++ b/src/spm_bpe_cache_merge.cc
@@ -1,4 +1,4 @@
-#ifdef __GLIBC__
+#ifdef __linux__
 #include <malloc.h>
 #endif
 
@@ -297,8 +297,10 @@ int main(int argc, char *argv[]) {
     LOG(INFO) << merged.sentences_size << " sentences, "
               << merged.required_chars.size() << " chars; allocated "
               << merged.allocated();
-    #if defined(TCMALLOC) and defined(__GLIBC__)
+    #if defined(TCMALLOC)
     MallocExtension::instance()->ReleaseFreeMemory();
+    #endif
+    #if defined(__linux__)
     malloc_stats();
     #endif
     if (++merged_count % save_interval == 0 && inputs.size() > 1) {

--- a/src/trainer_interface.cc
+++ b/src/trainer_interface.cc
@@ -14,7 +14,7 @@
 
 #include "trainer_interface.h"
 
-#ifdef __GLIBC__
+#ifdef __linux__
 #include <malloc.h>
 #endif
 
@@ -805,8 +805,10 @@ void TrainerInterface::SplitSentencesByWhitespace() {
     LOG(INFO) << "Compacted " << old_size << " -> " << pos;
   }
 
-  #if defined(TCMALLOC) and defined(__GLIBC__)
+  #if defined(TCMALLOC)
   MallocExtension::instance()->ReleaseFreeMemory();
+  #endif
+  #if defined(__linux__)
   malloc_stats();
   #endif
 }


### PR DESCRIPTION
Apparently there is an issue with using `__GLIBC__`, some hints of what is wrong could be found here https://stackoverflow.com/questions/4266354/how-to-tell-if-glibc-is-used/4266465#4266465
Using `__linux__` instead solves the problem.