### PR TITLE
Add more targets for wheels

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,7 +1,9 @@
 name: Build and Publish Wheels
 
 on:
-  workflow_dispatch:
+  # workflow_dispatch:
+    pull_request:
+      branches: [ main ]
   
 env:
   DOMAIN: poolside
@@ -12,6 +14,7 @@ jobs:
   build_wheels:
     strategy:
       matrix:
+        # os: [ubuntu-latest, macOS-latest]
         os: [ubuntu-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     name: Build wheels on ${{ matrix.os }}
@@ -65,8 +68,8 @@ jobs:
         working-directory: ${{github.workspace}}/python
         run: python -m cibuildwheel --output-dir ${{env.WHEEL_DST}}
         env:
-          CIBW_BUILD: "cp311-* cp312-*"
-          CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+          CIBW_ARCHS_LINUX: auto x86_64 aarch64
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_ARCHS_WINDOWS: auto ARM64
           CIBW_SKIP: "pp* *-musllinux_* *i686*"
@@ -88,4 +91,4 @@ jobs:
       - name: Publish
         run: |
           aws codeartifact login --tool twine --domain ${{env.DOMAIN}} --repository ${{ env.REPOSITORY }}
-          twine upload --verbose --repository codeartifact ${{env.WHEEL_DST}}/*
+          twine upload --skip-existing --verbose --repository codeartifact ${{env.WHEEL_DST}}/*

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,9 +1,8 @@
 name: Build and Publish Wheels
 
 on:
-  # workflow_dispatch:
-    pull_request:
-      branches: [ main ]
+  workflow_dispatch:
+
   
 env:
   DOMAIN: poolside
@@ -14,7 +13,6 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        # os: [ubuntu-latest, macOS-latest]
         os: [ubuntu-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     name: Build wheels on ${{ matrix.os }}


### PR DESCRIPTION
Adds support for Python 3.10.X and 3.13.X.
Also makes sure that if the wheel already exists the whole workflow does not fail and simply skips this particular wheel instead.