### PR TITLE
Publish wheels to both us-east-1 and us-east-2

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -88,5 +88,7 @@ jobs:
       
       - name: Publish
         run: |
-          aws codeartifact login --tool twine --domain ${{env.DOMAIN}} --repository ${{ env.REPOSITORY }}
-          twine upload --skip-existing --verbose --repository codeartifact ${{env.WHEEL_DST}}/*
+          for region in us-east-1 us-east-2; do
+            aws codeartifact login --tool twine --domain ${{env.DOMAIN}} --repository ${{ env.REPOSITORY }} --region $region
+            twine upload --skip-existing --verbose --repository codeartifact ${{env.WHEEL_DST}}/*
+          done


### PR DESCRIPTION
## Summary
Publish the built Python wheels to CodeArtifact in **both** `us-east-1` and `us-east-2`.

The **Publish** step now loops over both regions. Because `aws codeartifact login --tool twine` bakes the region-specific endpoint URL into the `codeartifact` repository entry in `~/.pypirc`, we log in to each region and upload immediately after — so the same wheels land in both regions. `--skip-existing` keeps it idempotent.

```yaml
for region in us-east-1 us-east-2; do
  aws codeartifact login --tool twine --domain $DOMAIN --repository $REPOSITORY --region $region
  twine upload --skip-existing --verbose --repository codeartifact $WHEEL_DST/*
done
```

## Notes
- The `poolside`/`poolside-packages-python` domain + repository and the `gh-action-publish-artifacts-role` IAM permissions for `us-east-2` have been verified to exist.
- The `Configure AWS Credentials` step's `aws-region: us-east-1` is unchanged; the per-region `--region` flag overrides it for each publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)